### PR TITLE
Add React Three Fiber portfolio scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Diretório de dependências do Node.js
+node_modules/
+
+#package-lock
+package-lock.json
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# IDE/Editor
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Sistema operacional
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
-"# victors-universe" 
+# Victor's Universe
+
+A modern developer portfolio built with React, Vite and React Three Fiber. Explore floating islands to learn more about Victor, his projects, skills and how to get in touch.
+
+## Inspiration
+
+Inspired by [david-hckh.com](https://www.david-hckh.com), this project creates an interactive 3D space using modern web technologies.
+
+## Technologies
+
+- React
+- Vite
+- React Three Fiber (Three.js)
+- Framer Motion
+- TailwindCSS
+
+## Getting Started
+
+### Installation
+
+```bash
+npm install
+```
+
+### Development
+
+```bash
+npm run dev
+```
+
+### Production Build
+
+```bash
+npm run build
+```
+
+### Preview Production Build
+
+```bash
+npm run preview
+```
+
+## Deployment
+
+The project can be deployed to any static hosting service that supports HTML and JavaScript. Run `npm run build` and upload the contents of the `dist` folder.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Victor's Universe</title>
+  </head>
+  <body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,25 +1,31 @@
 {
   "name": "victors-universe",
   "version": "1.0.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview"
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@react-three/drei": "^9.57.7",
+    "@react-three/fiber": "^8.13.5",
+    "framer-motion": "^10.12.16",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "@react-three/fiber": "^8.13.5",
-    "@react-three/drei": "^9.57.7",
-    "three": "^0.161.0",
-    "framer-motion": "^10.12.16"
+    "three": "^0.161.0"
   },
   "devDependencies": {
-    "typescript": "^5.3.3",
+    "@types/node": "^20.10.5",
+    "@types/react": "^18.2.45",
+    "@types/react-dom": "^18.2.18",
+    "@types/three": "^0.161.0",
     "@vitejs/plugin-react": "^4.2.0",
-    "vite": "^5.0.0",
-    "tailwindcss": "^3.3.5",
+    "autoprefixer": "^10.4.16",
     "postcss": "^8.4.25",
-    "autoprefixer": "^10.4.16"
+    "tailwindcss": "^3.3.5",
+    "typescript": "^5.3.3",
+    "vite": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "victors-universe",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@react-three/fiber": "^8.13.5",
+    "@react-three/drei": "^9.57.7",
+    "three": "^0.161.0",
+    "framer-motion": "^10.12.16"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3",
+    "@vitejs/plugin-react": "^4.2.0",
+    "vite": "^5.0.0",
+    "tailwindcss": "^3.3.5",
+    "postcss": "^8.4.25",
+    "autoprefixer": "^10.4.16"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,25 @@
+import { Canvas } from '@react-three/fiber'
+import { Suspense, useState } from 'react'
+import { OrbitControls, Stars } from '@react-three/drei'
+import { AnimatePresence } from 'framer-motion'
+import Scene from './components/Scene'
+import Overlay, { OverlayType } from './components/Overlay'
+
+export default function App() {
+  const [overlay, setOverlay] = useState<OverlayType | null>(null)
+
+  return (
+    <div className="h-full w-full relative">
+      <Canvas camera={{ position: [0, 0, 10] }}>
+        <ambientLight intensity={0.5} />
+        <pointLight position={[10, 10, 10]} />
+        <Suspense fallback={null}>
+          <Scene onSelect={setOverlay} />
+        </Suspense>
+        <Stars radius={100} count={5000} fade speed={2} />
+        <OrbitControls enablePan={false} />
+      </Canvas>
+      <AnimatePresence>{overlay && <Overlay type={overlay} onClose={() => setOverlay(null)} />}</AnimatePresence>
+    </div>
+  )
+}

--- a/src/components/Island.tsx
+++ b/src/components/Island.tsx
@@ -1,0 +1,22 @@
+import { MeshProps } from '@react-three/fiber'
+import { Html } from '@react-three/drei'
+import { motion } from 'framer-motion-3d'
+
+interface IslandProps extends MeshProps {
+  label: string
+  onClick: () => void
+}
+
+export default function Island({ label, onClick, ...props }: IslandProps) {
+  return (
+    <motion.mesh {...props} onClick={onClick} whileHover={{ scale: 1.2 }}>
+      <sphereGeometry args={[1, 32, 32]} />
+      <meshStandardMaterial color="#8B5CF6" />
+      <Html distanceFactor={10} position={[0, 1.5, 0]} className="select-none">
+        <div className="px-2 py-1 bg-white/80 dark:bg-gray-800/80 rounded text-sm">
+          {label}
+        </div>
+      </Html>
+    </motion.mesh>
+  )
+}

--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -1,0 +1,27 @@
+import { motion } from 'framer-motion'
+
+export type OverlayType = 'about' | 'projects' | 'skills' | 'contact'
+
+interface OverlayProps {
+  type: OverlayType
+  onClose: () => void
+}
+
+export default function Overlay({ type, onClose }: OverlayProps) {
+  return (
+    <motion.div
+      className="absolute inset-0 flex items-center justify-center bg-black/50 backdrop-blur"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+    >
+      <div className="bg-white dark:bg-gray-800 rounded p-6 max-w-md w-full">
+        <button className="float-right" onClick={onClose}>X</button>
+        <h2 className="text-xl mb-4 capitalize">{type}</h2>
+        <p>
+          This is the {type} section. Replace this text with your own content.
+        </p>
+      </div>
+    </motion.div>
+  )
+}

--- a/src/components/Scene.tsx
+++ b/src/components/Scene.tsx
@@ -1,0 +1,27 @@
+import { useFrame } from '@react-three/fiber'
+import { MeshProps } from '@react-three/fiber'
+import { useRef } from 'react'
+import Island from './Island'
+import { OverlayType } from './Overlay'
+
+interface SceneProps {
+  onSelect: (type: OverlayType) => void
+}
+
+export default function Scene({ onSelect }: SceneProps) {
+  const group = useRef<THREE.Group>(null!)
+
+  useFrame(({ clock }) => {
+    const t = clock.getElapsedTime()
+    group.current.rotation.y = t * 0.1
+  })
+
+  return (
+    <group ref={group}>
+      <Island position={[-4, 0, 0]} label="About" onClick={() => onSelect('about')} />
+      <Island position={[0, 0, 0]} label="Projects" onClick={() => onSelect('projects')} />
+      <Island position={[4, 0, 0]} label="Skills" onClick={() => onSelect('skills')} />
+      <Island position={[0, -3, 0]} label="Contact" onClick={() => onSelect('contact')} />
+    </group>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,14 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+  margin: 0;
+}
+
+canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>,
+)

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,21 +1,23 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "useDefineForClassFields": true,
     "lib": ["DOM", "DOM.Iterable", "ESNext"],
-    "allowJs": false,
-    "skipLibCheck": true,
-    "esModuleInterop": false,
-    "allowSyntheticDefaultImports": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "strict": true,
+    "jsx": "react-jsx",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
     "forceConsistentCasingInFileNames": true,
-    "module": "ESNext",
-    "moduleResolution": "Node",
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "baseUrl": "src",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "types": ["vite/client"]
   },
-  "include": ["src"],
-  "references": [{ "path": "./tsconfig.node.json" }]
+  "include": ["src", "types"],
+  "exclude": ["node_modules"]
 }

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})


### PR DESCRIPTION
## Summary
- set up React/Vite project with TailwindCSS
- integrate React Three Fiber for a floating island scene
- add interactive overlays for About, Projects, Skills and Contact
- document install and build steps

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68717e6b40a883279e857dc3ce839286