### PR TITLE
Add React Three Fiber portfolio project skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Diretório de dependências do Node.js
+node_modules/
+
+#package-lock
+package-lock.json
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# IDE/Editor
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?
+
+# Sistema operacional
+.DS_Store
+Thumbs.db

--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
-"# victors-universe" 
+# victors-universe
+
+An interactive 3D developer portfolio built with React, React Three Fiber and TailwindCSS.
+
+## Setup
+
+1. Install dependencies
+   ```bash
+   npm install
+   ```
+2. Start the development server
+   ```bash
+   npm run dev
+   ```
+3. Build for production
+   ```bash
+   npm run build
+   ```
+
+## Features
+- Animated floating islands representing portfolio sections
+- Smooth orbit camera controls
+- Responsive layout styled with TailwindCSS

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/public/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>victors-universe</title>
+  </head>
+  <body class="bg-gray-900">
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "victors-universe",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "three": "^0.160.0",
+    "@react-three/fiber": "^8.13.3",
+    "@react-three/drei": "^9.88.9",
+    "@react-three/motion": "^2.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.14",
+    "@types/react-dom": "^18.2.6",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.15",
+    "postcss": "^8.4.26",
+    "tailwindcss": "^3.4.1",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <circle cx="50" cy="50" r="50" fill="currentColor" />
+</svg>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,19 @@
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import Island from './components/Island';
+
+export default function App() {
+  return (
+    <div className="w-full h-full">
+      <Canvas camera={{ position: [0, 2, 10], fov: 50 }}>
+        <ambientLight intensity={0.3} />
+        <pointLight position={[5, 5, 5]} intensity={1} />
+        <Island position={[-3, 0, 0]} label="About Me" />
+        <Island position={[0, 0, -3]} label="Projects" />
+        <Island position={[3, 0, 0]} label="Skills" />
+        <Island position={[0, 0, 3]} label="Contact" />
+        <OrbitControls enablePan={false} />
+      </Canvas>
+    </div>
+  );
+}

--- a/src/components/Island.tsx
+++ b/src/components/Island.tsx
@@ -1,0 +1,29 @@
+import { Html } from '@react-three/drei';
+import { motion } from '@react-three/motion';
+import { FC } from 'react';
+
+type IslandProps = {
+  position: [number, number, number];
+  label: string;
+  onClick?: () => void;
+};
+
+const Island: FC<IslandProps> = ({ position, label, onClick }) => {
+  return (
+    <motion.mesh
+      position={position}
+      onClick={onClick}
+      whileHover={{ scale: 1.1, rotateY: 0.2 }}
+    >
+      <icosahedronGeometry args={[1, 1]} />
+      <meshStandardMaterial color="#4ade80" />
+      <Html distanceFactor={8} className="pointer-events-none">
+        <div className="text-white text-sm bg-black/50 px-2 py-1 rounded-md">
+          {label}
+        </div>
+      </Html>
+    </motion.mesh>
+  );
+};
+
+export default Island;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,8 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  height: 100%;
+  margin: 0;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- initialize a Vite + React project
- set up TailwindCSS and TypeScript
- add 3D scene with floating islands
- include favicon and build configs

## Testing
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687182eb415483279369ffc3a97f193f