### PR TITLE
Initialize React 3D portfolio project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.env
+.DS_Store
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-"# victors-universe" 
+# Victor's Universe
+
+An interactive 3D developer portfolio built with React, Three.js and TailwindCSS.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+3. Build for production:
+   ```bash
+   npm run build
+   ```
+
+Ensure you have Node.js installed. The project uses Vite for fast development and `@react-three/fiber` for 3D rendering.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Victor's Universe</title>
+  <link rel="stylesheet" href="/src/index.css" />
+</head>
+<body class="bg-gray-900 text-white">
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "victors-universe",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "three": "^0.160.0",
+    "@react-three/fiber": "^8.16.7",
+    "@react-three/drei": "^9.87.3",
+    "@react-spring/three": "^9.7.2"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.0",
+    "@types/react": "^18.2.24",
+    "@types/react-dom": "^18.2.11",
+    "vite": "^5.2.0",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.31",
+    "autoprefixer": "^10.4.17"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,25 @@
+import { Canvas } from '@react-three/fiber';
+import { OrbitControls } from '@react-three/drei';
+import Island from './Island';
+
+export default function App() {
+  const islands = [
+    { label: 'About Me', position: [-2, 0, 0] },
+    { label: 'Projects', position: [0, 0, 0] },
+    { label: 'Skills', position: [2, 0, 0] },
+    { label: 'Contact', position: [4, 0, 0] },
+  ];
+
+  return (
+    <div className="w-full h-full">
+      <Canvas camera={{ position: [0, 2, 10] }}>
+        <ambientLight intensity={0.5} />
+        <pointLight position={[10, 10, 10]} />
+        {islands.map((island) => (
+          <Island key={island.label} position={island.position} label={island.label} />
+        ))}
+        <OrbitControls />
+      </Canvas>
+    </div>
+  );
+}

--- a/src/Island.tsx
+++ b/src/Island.tsx
@@ -1,0 +1,35 @@
+import { useRef } from 'react';
+import { MeshProps } from '@react-three/fiber';
+import { useFrame } from '@react-three/fiber';
+import { Html } from '@react-three/drei';
+import { useSpring, a } from '@react-spring/three';
+
+interface IslandProps extends MeshProps {
+  label: string;
+}
+
+export default function Island({ label, ...props }: IslandProps) {
+  const ref = useRef<THREE.Mesh>(null!);
+  const { scale } = useSpring({
+    from: { scale: 1 },
+    to: { scale: 1.05 },
+    loop: { reverse: true },
+    config: { mass: 1, tension: 100, friction: 20 },
+  });
+
+  useFrame(({ clock }) => {
+    if (ref.current) {
+      ref.current.position.y += Math.sin(clock.getElapsedTime() + props.position![0]) * 0.001;
+    }
+  });
+
+  return (
+    <a.mesh ref={ref} {...props} scale={scale} onClick={() => console.log(label)}>
+      <boxGeometry args={[1, 0.5, 1]} />
+      <meshStandardMaterial color="#8ED6FF" />
+      <Html distanceFactor={10} position={[0, 0.5, 0]}>
+        <div className="px-2 py-1 bg-black bg-opacity-50 rounded text-sm">{label}</div>
+      </Html>
+    </a.mesh>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,9 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+html, body, #root {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['index.html', 'src/**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "useDefineForClassFields": true,
+    "module": "esnext",
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- create Vite/React project files with TypeScript
- add TailwindCSS setup and PostCSS config
- implement Island component with spring animation
- build 3D scene in App
- include starter README and .gitignore

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_687186cf239083278d84a43c1d1db8e2